### PR TITLE
correct 'corners' typos in source and README

### DIFF
--- a/Demo/Base.lproj/Main.storyboard
+++ b/Demo/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="j89-zd-GID">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="j89-zd-GID">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -54,7 +54,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="leftKnobHeight">
                                         <real key="value" value="30"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCorners">
                                         <real key="value" value="15"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="scaleMinValue">
@@ -84,7 +84,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="identifier">
                                         <integer key="value" value="1001"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCorners">
                                         <real key="value" value="15"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="rangeNotSelectedGradientColor1">
@@ -150,7 +150,7 @@
                                     <userDefinedRuntimeAttribute type="color" keyPath="rightShadowColor">
                                         <color key="value" red="1" green="0.94227303330000001" blue="0.2415095256" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="barCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="barCorners">
                                         <real key="value" value="6"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="defaultValueLeftKnob">
@@ -182,13 +182,13 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="leftKnobHeight">
                                         <real key="value" value="40"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCorners">
                                         <real key="value" value="0.0"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="leftKnobWidth">
                                         <real key="value" value="40"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCorners">
                                         <real key="value" value="0.0"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="identifier">
@@ -242,7 +242,7 @@
                                     <userDefinedRuntimeAttribute type="point" keyPath="rangeSelectedGradientEndPoint">
                                         <point key="value" x="0.0" y="1"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="barCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="barCorners">
                                         <real key="value" value="3"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="image" keyPath="rangeNotSelectedBackgroundImage" value="rangeNotSelected"/>
@@ -270,7 +270,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="barHeight">
                                         <real key="value" value="15"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="barCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="barCorners">
                                         <real key="value" value="5"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="rangeSelectedColor">
@@ -285,7 +285,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="leftKnobHeight">
                                         <real key="value" value="30"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCorners">
                                         <real key="value" value="15"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="leftShadowOpacity">
@@ -306,7 +306,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="rightKnobHeight">
                                         <real key="value" value="56"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCorners">
                                         <real key="value" value="28"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="rightShadowOpacity">
@@ -405,7 +405,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="wjV-jt-TfT">
-                                            <rect key="frame" x="16" y="0.0" width="344" height="43.5"/>
+                                            <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -459,7 +459,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="barTrailing">
                                         <real key="value" value="30"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="barCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="barCorners">
                                         <real key="value" value="7"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="rangeSelectedBackgroundEdgeInsetTop">
@@ -494,7 +494,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="rightKnobHeight">
                                         <real key="value" value="40"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCorners">
                                         <real key="value" value="20"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="leftKnobWidth">
@@ -512,7 +512,7 @@
                                     <userDefinedRuntimeAttribute type="color" keyPath="barShadowColor">
                                         <color key="value" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCorners">
                                         <real key="value" value="20"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="image" keyPath="rangeSelectedBackgroundImage" value="rangeSelected"/>
@@ -581,7 +581,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="leftKnobHeight">
                                         <real key="value" value="40"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCorners">
                                         <real key="value" value="20"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="leftKnobGradientColor1">
@@ -602,7 +602,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="rightKnobHeight">
                                         <real key="value" value="40"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCorners">
                                         <real key="value" value="20"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="rightKnobGradientColor1">
@@ -620,7 +620,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="barHeight">
                                         <real key="value" value="16"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="barCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="barCorners">
                                         <real key="value" value="8"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
@@ -669,7 +669,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="leftKnobHeight">
                                         <real key="value" value="40"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCorners">
                                         <real key="value" value="20"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="leftKnobColor">
@@ -696,7 +696,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="rightKnobHeight">
                                         <real key="value" value="40"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCorners">
                                         <real key="value" value="20"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="rightShadowOpacity">
@@ -717,7 +717,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="barTrailing">
                                         <real key="value" value="30"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="barCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="barCorners">
                                         <real key="value" value="3"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="barShadowOpacity">
@@ -750,16 +750,16 @@
                                     <userDefinedRuntimeAttribute type="color" keyPath="leftKnobColor">
                                         <color key="value" red="0.6474609375" green="0.29729824643566949" blue="0.38843987879908037" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCorners">
                                         <real key="value" value="5"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="rightKnobColor">
                                         <color key="value" red="0.6474609375" green="0.29729824643566949" blue="0.38843987879908037" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCorners">
                                         <real key="value" value="5"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="barCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="barCorners">
                                         <real key="value" value="1"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
@@ -789,7 +789,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="barHeight">
                                         <real key="value" value="15"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="barCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="barCorners">
                                         <real key="value" value="15"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="leftKnobWidth">
@@ -798,7 +798,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="leftKnobHeight">
                                         <real key="value" value="50"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="leftKnobCorners">
                                         <real key="value" value="30"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="rightKnobWidth">
@@ -807,7 +807,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="rightKnobHeight">
                                         <real key="value" value="50"/>
                                     </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCornes">
+                                    <userDefinedRuntimeAttribute type="number" keyPath="rightKnobCorners">
                                         <real key="value" value="30"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="barLeading">

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ This is the list of the current customizable property of the RangeUISlider direc
  - bar height 
  - bar leading distance from container view
  - bar trailing distance from container view
- - bar cornes
+ - bar corners
  - bar shadow opacity
  - bar shadow color
  - bar shadow offset

--- a/Source/RangeUISlider.swift
+++ b/Source/RangeUISlider.swift
@@ -176,10 +176,10 @@ import UIKit
         }
     }
     /// Left knob corners.
-    @IBInspectable var leftKnobCornes: CGFloat = 15.0 {
+    @IBInspectable var leftKnobCorners: CGFloat = 15.0 {
         didSet {
-            leftKnob.backgroundView.layer.cornerRadius = leftKnobCornes
-            leftKnob.backgroundView.layer.masksToBounds = leftKnobCornes > 0.0
+            leftKnob.backgroundView.layer.cornerRadius = leftKnobCorners
+            leftKnob.backgroundView.layer.masksToBounds = leftKnobCorners > 0.0
         }
     }
     /// Left knob image.
@@ -225,7 +225,7 @@ import UIKit
                                       secondColor: leftKnobGradientColor2,
                                       startPoint: leftKnobGradientStartPoint,
                                       endPoint: leftKnobGradientEndPoint,
-                                      cornerRadius: leftKnobCornes)
+                                      cornerRadius: leftKnobCorners)
         }
     }
     /// Gradient color 2 for range not selected.
@@ -235,7 +235,7 @@ import UIKit
                                       secondColor: leftKnobGradientColor2,
                                       startPoint: leftKnobGradientStartPoint,
                                       endPoint: leftKnobGradientEndPoint,
-                                      cornerRadius: leftKnobCornes)
+                                      cornerRadius: leftKnobCorners)
         }
     }
     /// Gradient start point for not selected range.
@@ -245,7 +245,7 @@ import UIKit
                                       secondColor: leftKnobGradientColor2,
                                       startPoint: leftKnobGradientStartPoint,
                                       endPoint: leftKnobGradientEndPoint,
-                                      cornerRadius: leftKnobCornes)
+                                      cornerRadius: leftKnobCorners)
         }
     }
     /// Gradient end point for not selected range.
@@ -255,7 +255,7 @@ import UIKit
                                       secondColor: leftKnobGradientColor2,
                                       startPoint: leftKnobGradientStartPoint,
                                       endPoint: leftKnobGradientEndPoint,
-                                      cornerRadius: leftKnobCornes)
+                                      cornerRadius: leftKnobCorners)
         }
     }
     /// Left knob border width.
@@ -263,7 +263,7 @@ import UIKit
         didSet {
             leftKnob.addBorders(usingColor: leftKnobBorderColor,
                                      andWidth: leftKnobBorderWidth,
-                                     andCorners: leftKnobCornes)
+                                     andCorners: leftKnobCorners)
         }
     }
     /// Left knob border color.
@@ -271,7 +271,7 @@ import UIKit
         didSet {
             leftKnob.addBorders(usingColor: leftKnobBorderColor,
                                      andWidth: leftKnobBorderWidth,
-                                     andCorners: leftKnobCornes)
+                                     andCorners: leftKnobCorners)
         }
     }
     /// Right knob width.
@@ -287,10 +287,10 @@ import UIKit
         }
     }
     /// Right knob corners.
-    @IBInspectable var rightKnobCornes: CGFloat = 15.0 {
+    @IBInspectable var rightKnobCorners: CGFloat = 15.0 {
         didSet {
-            rightKnob.backgroundView.layer.cornerRadius = rightKnobCornes
-            rightKnob.backgroundView.layer.masksToBounds = rightKnobCornes > 0.0
+            rightKnob.backgroundView.layer.cornerRadius = rightKnobCorners
+            rightKnob.backgroundView.layer.masksToBounds = rightKnobCorners > 0.0
         }
     }
     /// Right knob image.
@@ -336,7 +336,7 @@ import UIKit
                                        secondColor: rightKnobGradientColor2,
                                        startPoint: rightKnobGradientStartPoint,
                                        endPoint: rightKnobGradientEndPoint,
-                                       cornerRadius: rightKnobCornes)
+                                       cornerRadius: rightKnobCorners)
         }
     }
     /// Gradient color 2 for range not selected.
@@ -346,7 +346,7 @@ import UIKit
                                        secondColor: rightKnobGradientColor2,
                                        startPoint: rightKnobGradientStartPoint,
                                        endPoint: rightKnobGradientEndPoint,
-                                       cornerRadius: rightKnobCornes)
+                                       cornerRadius: rightKnobCorners)
         }
     }
     /// Gradient start point for not selected range.
@@ -356,7 +356,7 @@ import UIKit
                                        secondColor: rightKnobGradientColor2,
                                        startPoint: rightKnobGradientStartPoint,
                                        endPoint: rightKnobGradientEndPoint,
-                                       cornerRadius: rightKnobCornes)
+                                       cornerRadius: rightKnobCorners)
         }
     }
     /// Gradient end point for not selected range.
@@ -366,7 +366,7 @@ import UIKit
                                        secondColor: rightKnobGradientColor2,
                                        startPoint: rightKnobGradientStartPoint,
                                        endPoint: rightKnobGradientEndPoint,
-                                       cornerRadius: rightKnobCornes)
+                                       cornerRadius: rightKnobCorners)
         }
     }
     /// Right knob border width.
@@ -374,7 +374,7 @@ import UIKit
         didSet {
             rightKnob.addBorders(usingColor: rightKnobBorderColor,
                                       andWidth: rightKnobBorderWidth,
-                                      andCorners: rightKnobCornes)
+                                      andCorners: rightKnobCorners)
         }
     }
     /// Right knob border color.
@@ -382,7 +382,7 @@ import UIKit
         didSet {
             rightKnob.addBorders(usingColor: rightKnobBorderColor,
                                       andWidth: rightKnobBorderWidth,
-                                      andCorners: rightKnobCornes)
+                                      andCorners: rightKnobCorners)
         }
     }
     /// Bar height.
@@ -404,10 +404,10 @@ import UIKit
         }
     }
     /// Bar corners.
-    @IBInspectable var barCornes: CGFloat = 0.0 {
+    @IBInspectable var barCorners: CGFloat = 0.0 {
         didSet {
-            leftProgressView.layer.cornerRadius = barCornes
-            rightProgressView.layer.cornerRadius = barCornes
+            leftProgressView.layer.cornerRadius = barCorners
+            rightProgressView.layer.cornerRadius = barCorners
             addGradientToNotSelectedRangeIfNeeded()
             addBackgroundToRangeNotSelectedIfNeeded()
         }
@@ -583,12 +583,12 @@ import UIKit
                                           secondColor: rangeNotSelectedGradientColor2,
                                           startPoint: rangeNotSelectedGradientStartPoint,
                                           endPoint: rangeNotSelectedGradientEndPoint,
-                                          cornerRadius: barCornes)
+                                          cornerRadius: barCorners)
         rightProgressView.addGradient(firstColor: rangeNotSelectedGradientColor1,
                                            secondColor: rangeNotSelectedGradientColor2,
                                            startPoint: rangeNotSelectedGradientStartPoint,
                                            endPoint: rangeNotSelectedGradientEndPoint,
-                                           cornerRadius: barCornes)
+                                           cornerRadius: barCorners)
     }
     
     /**
@@ -602,10 +602,10 @@ import UIKit
                                          right: rangeNotSelectedBackgroundEdgeInsetRight)
             leftProgressView.addBackground(usingImage: backgroundImage,
                                                 andEdgeInset: edgeInset,
-                                                andCorners: barCornes)
+                                                andCorners: barCorners)
             rightProgressView.addBackground(usingImage: backgroundImage,
                                                  andEdgeInset: edgeInset,
-                                                 andCorners: barCornes)
+                                                 andCorners: barCorners)
         }
     }
     
@@ -620,7 +620,7 @@ import UIKit
                                          right: rangeSelectedBackgroundEdgeInsetRight)
             selectedProgressView.addBackground(usingImage: backgroundImage,
                                                     andEdgeInset: edgeInset,
-                                                    andCorners: barCornes)
+                                                    andCorners: barCorners)
         }
     }
     


### PR DESCRIPTION
I noticed a few places where the typo `cornes` snuck in, so this corrects them all to `corners`.