### PR TITLE
[ISSUE-46] Fixed an issue, minimum value wasn't reset

### DIFF
--- a/Source/Logic/ProgrammaticKnobChange.swift
+++ b/Source/Logic/ProgrammaticKnobChange.swift
@@ -61,7 +61,7 @@ class ProgrammaticKnobChange {
     }
 
     private func isValidForLeftKnob(value: CGFloat) -> Bool {
-        return value > delegate.properties.scale.scaleMinValue
+        return value >= delegate.properties.scale.scaleMinValue
             && value <= delegate.properties.previousRangeSelected.maxValue
     }
 

--- a/Source/Logic/RangeUpdater.swift
+++ b/Source/Logic/RangeUpdater.swift
@@ -43,7 +43,7 @@ class RangeUpdater: KnobGestureManagerDelegate {
     internal func rangeSelectionFinished() {
         let rangeSelected = calculateSelectedRange()
 
-        if !rangeSelected.maxValue.isNaN && !rangeSelected.maxValue.isNaN {
+        if !rangeSelected.minValue.isNaN && !rangeSelected.maxValue.isNaN {
             delegate.rangeChangeFinished(
                 minValueSelected: rangeSelected.minValue,
                 maxValueSelected: rangeSelected.maxValue


### PR DESCRIPTION
Fixed issue-46.

## Description
When a value is programmatic assigned to the LeftKnob, the minimum value is not applied.

## Motivation and Context
 Let user can change the value of LeftKnob of RangeUISlider to the minimum value through another component.

## Types of changes
- [X] Bug fix :bug: (non-breaking change which fixes an issue)
- [ ] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/RangeUISlider/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
