### PR TITLE
Programmatic change detection

### DIFF
--- a/RangeUISlider.xcodeproj/project.pbxproj
+++ b/RangeUISlider.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		45263E8B25C9D18B005D994A /* ProgrammaticKnobChangeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45263E8A25C9D18B005D994A /* ProgrammaticKnobChangeDelegate.swift */; };
 		45263E9325C9D1FD005D994A /* RangeSelected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45263E9225C9D1FD005D994A /* RangeSelected.swift */; };
 		45263E9825C9D3B2005D994A /* KnobsHorizontalPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45263E9725C9D3B2005D994A /* KnobsHorizontalPosition.swift */; };
+		4528C9AB2877010500154EF4 /* RangeUISliderDelegateEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4528C9AA2877010500154EF4 /* RangeUISliderDelegateEvents.swift */; };
 		4538955425C5D62700389905 /* RangeUISliderCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4538955325C5D62700389905 /* RangeUISliderCreator.swift */; };
 		4538956F25C5DF8700389905 /* KnobPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4538956E25C5DF8700389905 /* KnobPosition.swift */; };
 		455BF125259B44F80026BE56 /* InsideTableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455BF124259B44F80026BE56 /* InsideTableViewTests.swift */; };
@@ -149,6 +150,7 @@
 		45263E8A25C9D18B005D994A /* ProgrammaticKnobChangeDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgrammaticKnobChangeDelegate.swift; sourceTree = "<group>"; };
 		45263E9225C9D1FD005D994A /* RangeSelected.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeSelected.swift; sourceTree = "<group>"; };
 		45263E9725C9D3B2005D994A /* KnobsHorizontalPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnobsHorizontalPosition.swift; sourceTree = "<group>"; };
+		4528C9AA2877010500154EF4 /* RangeUISliderDelegateEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeUISliderDelegateEvents.swift; sourceTree = "<group>"; };
 		4538955325C5D62700389905 /* RangeUISliderCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeUISliderCreator.swift; sourceTree = "<group>"; };
 		4538956E25C5DF8700389905 /* KnobPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnobPosition.swift; sourceTree = "<group>"; };
 		455BF124259B44F80026BE56 /* InsideTableViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsideTableViewTests.swift; sourceTree = "<group>"; };
@@ -412,6 +414,7 @@
 				450C7B5425C48A4F00764496 /* Logic */,
 				450C7B5E25C48A7400764496 /* UI */,
 				5F7B1B721F7EEE7E00D19E23 /* RangeUISliderDelegate.swift */,
+				4528C9AA2877010500154EF4 /* RangeUISliderDelegateEvents.swift */,
 				4571869325A5CFE300541D67 /* RangeSliderCoordinator.swift */,
 				4571869825A5D01500541D67 /* RangeSliderSettings.swift */,
 				45E215271E8E812E00F0B8B9 /* RangeUISlider.h */,
@@ -695,6 +698,7 @@
 				457A1DE725E6CD7300180CAD /* KnobComponents.swift in Sources */,
 				45D2B83725C5CBD500DFD838 /* ConstraintAttributes.swift in Sources */,
 				45E9D5A425C6FD9A00FE6E3F /* MatchingMarginsConstraintFactory.swift in Sources */,
+				4528C9AB2877010500154EF4 /* RangeUISliderDelegateEvents.swift in Sources */,
 				45E2B6F225C987F1007CCBB5 /* ProgrammaticKnobChange.swift in Sources */,
 				45E9D59725C6F94200FE6E3F /* BarProperties.swift in Sources */,
 				450C7B4E25C489E200764496 /* PositionConstraintFactory.swift in Sources */,

--- a/RangeUISliderDemo/ChangeDefaultKnobsValuesProgrammaticViewController.swift
+++ b/RangeUISliderDemo/ChangeDefaultKnobsValuesProgrammaticViewController.swift
@@ -149,18 +149,13 @@ class ChangeDefaultKnobsValuesProgrammaticViewController: UIViewController, Rang
         }
     }
 
-    func rangeChangeFinished(
-        minValueSelected: CGFloat,
-        maxValueSelected: CGFloat,
-        slider: RangeUISlider,
-        userInteraction: Bool
-    ) {
-        print("FINISH min: \(minValueSelected) -  max: \(maxValueSelected) - identifier: \(slider.identifier)")
-        minValueSelectedLabel.text = minValueSelected.description
-        maxValueSelectedLabel.text = maxValueSelected.description
+    func rangeChangeFinished(event: RangeUISliderChangeFinishedEvent) {
+        print("FINISH min: \(event.minValueSelected) - max: \(event.maxValueSelected)")
+        minValueSelectedLabel.text = event.minValueSelected.description
+        maxValueSelectedLabel.text = event.maxValueSelected.description
     }
 
-    func rangeIsChanging(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
-        print("min: \(minValueSelected) -  max: \(maxValueSelected) - identifier: \(slider.identifier)")
+    func rangeIsChanging(event: RangeUISliderChangeEvent) {
+        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected) - identifier: \(event.slider.identifier)")
     }
 }

--- a/RangeUISliderDemo/ChangeDefaultKnobsValuesProgrammaticViewController.swift
+++ b/RangeUISliderDemo/ChangeDefaultKnobsValuesProgrammaticViewController.swift
@@ -149,7 +149,12 @@ class ChangeDefaultKnobsValuesProgrammaticViewController: UIViewController, Rang
         }
     }
 
-    func rangeChangeFinished(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
+    func rangeChangeFinished(
+        minValueSelected: CGFloat,
+        maxValueSelected: CGFloat,
+        slider: RangeUISlider,
+        userInteraction: Bool
+    ) {
         print("FINISH min: \(minValueSelected) -  max: \(maxValueSelected) - identifier: \(slider.identifier)")
         minValueSelectedLabel.text = minValueSelected.description
         maxValueSelectedLabel.text = maxValueSelected.description

--- a/RangeUISliderDemo/ChangeDefaultKnobsValuesProgrammaticViewController.swift
+++ b/RangeUISliderDemo/ChangeDefaultKnobsValuesProgrammaticViewController.swift
@@ -150,12 +150,13 @@ class ChangeDefaultKnobsValuesProgrammaticViewController: UIViewController, Rang
     }
 
     func rangeChangeFinished(event: RangeUISliderChangeFinishedEvent) {
+        print("FINISH: \(event.slider.identifier)")
         print("FINISH min: \(event.minValueSelected) - max: \(event.maxValueSelected)")
         minValueSelectedLabel.text = event.minValueSelected.description
         maxValueSelectedLabel.text = event.maxValueSelected.description
     }
 
     func rangeIsChanging(event: RangeUISliderChangeEvent) {
-        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected) - identifier: \(event.slider.identifier)")
+        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected)")
     }
 }

--- a/RangeUISliderDemo/ChangeKnobsProgrammaticViewController.swift
+++ b/RangeUISliderDemo/ChangeKnobsProgrammaticViewController.swift
@@ -153,12 +153,13 @@ class ChangeKnobsProgrammaticViewController: UIViewController, RangeUISliderDele
     }
 
     func rangeChangeFinished(event: RangeUISliderChangeFinishedEvent) {
+        print("FINISH: \(event.slider.identifier)")
         print("FINISH min: \(event.minValueSelected) - max: \(event.maxValueSelected)")
         minValueSelectedLabel.text = event.minValueSelected.description
         maxValueSelectedLabel.text = event.maxValueSelected.description
     }
 
     func rangeIsChanging(event: RangeUISliderChangeEvent) {
-        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected) - identifier: \(event.slider.identifier)")
+        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected)")
     }
 }

--- a/RangeUISliderDemo/ChangeKnobsProgrammaticViewController.swift
+++ b/RangeUISliderDemo/ChangeKnobsProgrammaticViewController.swift
@@ -152,18 +152,13 @@ class ChangeKnobsProgrammaticViewController: UIViewController, RangeUISliderDele
         }
     }
 
-    func rangeChangeFinished(
-        minValueSelected: CGFloat,
-        maxValueSelected: CGFloat,
-        slider: RangeUISlider,
-        userInteraction: Bool
-    ) {
-        print("FINISH min: \(minValueSelected) -  max: \(maxValueSelected) - identifier: \(slider.identifier)")
-        minValueSelectedLabel.text = minValueSelected.description
-        maxValueSelectedLabel.text = maxValueSelected.description
+    func rangeChangeFinished(event: RangeUISliderChangeFinishedEvent) {
+        print("FINISH min: \(event.minValueSelected) - max: \(event.maxValueSelected)")
+        minValueSelectedLabel.text = event.minValueSelected.description
+        maxValueSelectedLabel.text = event.maxValueSelected.description
     }
 
-    func rangeIsChanging(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
-        print("min: \(minValueSelected) -  max: \(maxValueSelected) - identifier: \(slider.identifier)")
+    func rangeIsChanging(event: RangeUISliderChangeEvent) {
+        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected) - identifier: \(event.slider.identifier)")
     }
 }

--- a/RangeUISliderDemo/ChangeKnobsProgrammaticViewController.swift
+++ b/RangeUISliderDemo/ChangeKnobsProgrammaticViewController.swift
@@ -152,7 +152,12 @@ class ChangeKnobsProgrammaticViewController: UIViewController, RangeUISliderDele
         }
     }
 
-    func rangeChangeFinished(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
+    func rangeChangeFinished(
+        minValueSelected: CGFloat,
+        maxValueSelected: CGFloat,
+        slider: RangeUISlider,
+        userInteraction: Bool
+    ) {
         print("FINISH min: \(minValueSelected) -  max: \(maxValueSelected) - identifier: \(slider.identifier)")
         minValueSelectedLabel.text = minValueSelected.description
         maxValueSelectedLabel.text = maxValueSelected.description

--- a/RangeUISliderDemo/ChangeScaleProgrammaticViewController.swift
+++ b/RangeUISliderDemo/ChangeScaleProgrammaticViewController.swift
@@ -157,13 +157,14 @@ class ChangeScaleProgrammaticViewController: UIViewController, RangeUISliderDele
     }
 
     func rangeChangeFinished(event: RangeUISliderChangeFinishedEvent) {
+        print("FINISH: \(event.slider.identifier)")
         print("FINISH min: \(event.minValueSelected) - max: \(event.maxValueSelected)")
         minValueSelectedLabel.text = event.minValueSelected.description
         maxValueSelectedLabel.text = event.maxValueSelected.description
     }
 
     func rangeIsChanging(event: RangeUISliderChangeEvent) {
-        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected) - identifier: \(event.slider.identifier)")
+        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected)")
     }
 
 }

--- a/RangeUISliderDemo/ChangeScaleProgrammaticViewController.swift
+++ b/RangeUISliderDemo/ChangeScaleProgrammaticViewController.swift
@@ -156,7 +156,12 @@ class ChangeScaleProgrammaticViewController: UIViewController, RangeUISliderDele
         }
     }
 
-    func rangeChangeFinished(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
+    func rangeChangeFinished(
+        minValueSelected: CGFloat,
+        maxValueSelected: CGFloat,
+        slider: RangeUISlider,
+        userInteraction: Bool
+    ) {
         print("FINISH min: \(minValueSelected) -  max: \(maxValueSelected) - identifier: \(slider.identifier)")
         minValueSelectedLabel.text = minValueSelected.description
         maxValueSelectedLabel.text = maxValueSelected.description

--- a/RangeUISliderDemo/ChangeScaleProgrammaticViewController.swift
+++ b/RangeUISliderDemo/ChangeScaleProgrammaticViewController.swift
@@ -156,18 +156,14 @@ class ChangeScaleProgrammaticViewController: UIViewController, RangeUISliderDele
         }
     }
 
-    func rangeChangeFinished(
-        minValueSelected: CGFloat,
-        maxValueSelected: CGFloat,
-        slider: RangeUISlider,
-        userInteraction: Bool
-    ) {
-        print("FINISH min: \(minValueSelected) -  max: \(maxValueSelected) - identifier: \(slider.identifier)")
-        minValueSelectedLabel.text = minValueSelected.description
-        maxValueSelectedLabel.text = maxValueSelected.description
+    func rangeChangeFinished(event: RangeUISliderChangeFinishedEvent) {
+        print("FINISH min: \(event.minValueSelected) - max: \(event.maxValueSelected)")
+        minValueSelectedLabel.text = event.minValueSelected.description
+        maxValueSelectedLabel.text = event.maxValueSelected.description
     }
 
-    func rangeIsChanging(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
-        print("min: \(minValueSelected) -  max: \(maxValueSelected) - identifier: \(slider.identifier)")
+    func rangeIsChanging(event: RangeUISliderChangeEvent) {
+        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected) - identifier: \(event.slider.identifier)")
     }
+
 }

--- a/RangeUISliderDemo/MixedFeaturesViewController.swift
+++ b/RangeUISliderDemo/MixedFeaturesViewController.swift
@@ -24,17 +24,14 @@ class MixedFeaturesViewController: UIViewController, RangeUISliderDelegate {
         print("range modification start")
     }
 
-    func rangeIsChanging(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
-        // print("min: \(minValueSelected) -  max: \(maxValueSelected) - identifier: \(slider.identifier)")
+    func rangeChangeFinished(event: RangeUISliderChangeFinishedEvent) {
+        print("FINISH min: \(event.minValueSelected) - max: \(event.maxValueSelected)")
+        minValueSelectedLabel.text = event.minValueSelected.description
+        maxValueSelectedLabel.text = event.maxValueSelected.description
     }
 
-    func rangeChangeFinished(
-        minValueSelected: CGFloat,
-        maxValueSelected: CGFloat,
-        slider: RangeUISlider,
-        userInteraction: Bool
-    ) {
-        minValueSelectedLabel.text = minValueSelected.description
-        maxValueSelectedLabel.text = maxValueSelected.description
+    func rangeIsChanging(event: RangeUISliderChangeEvent) {
+        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected) - identifier: \(event.slider.identifier)")
     }
+
 }

--- a/RangeUISliderDemo/MixedFeaturesViewController.swift
+++ b/RangeUISliderDemo/MixedFeaturesViewController.swift
@@ -28,7 +28,12 @@ class MixedFeaturesViewController: UIViewController, RangeUISliderDelegate {
         // print("min: \(minValueSelected) -  max: \(maxValueSelected) - identifier: \(slider.identifier)")
     }
 
-    func rangeChangeFinished(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
+    func rangeChangeFinished(
+        minValueSelected: CGFloat,
+        maxValueSelected: CGFloat,
+        slider: RangeUISlider,
+        userInteraction: Bool
+    ) {
         minValueSelectedLabel.text = minValueSelected.description
         maxValueSelectedLabel.text = maxValueSelected.description
     }

--- a/RangeUISliderDemo/MixedFeaturesViewController.swift
+++ b/RangeUISliderDemo/MixedFeaturesViewController.swift
@@ -25,13 +25,14 @@ class MixedFeaturesViewController: UIViewController, RangeUISliderDelegate {
     }
 
     func rangeChangeFinished(event: RangeUISliderChangeFinishedEvent) {
+        print("FINISH: \(event.slider.identifier)")
         print("FINISH min: \(event.minValueSelected) - max: \(event.maxValueSelected)")
         minValueSelectedLabel.text = event.minValueSelected.description
         maxValueSelectedLabel.text = event.maxValueSelected.description
     }
 
     func rangeIsChanging(event: RangeUISliderChangeEvent) {
-        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected) - identifier: \(event.slider.identifier)")
+        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected)")
     }
 
 }

--- a/RangeUISliderDemo/SetupProgrammaticViewController.swift
+++ b/RangeUISliderDemo/SetupProgrammaticViewController.swift
@@ -77,16 +77,11 @@ class SetupProgrammaticViewController: UIViewController, RangeUISliderDelegate {
 
     }
 
-    func rangeChangeFinished(
-        minValueSelected: CGFloat,
-        maxValueSelected: CGFloat,
-        slider: RangeUISlider,
-        userInteraction: Bool
-    ) {
-        print("FINISH min: \(minValueSelected) -  max: \(maxValueSelected) - identifier: \(slider.identifier)")
+    func rangeChangeFinished(event: RangeUISliderChangeFinishedEvent) {
+        print("FINISH min: \(event.minValueSelected) - max: \(event.maxValueSelected)")
     }
 
-    func rangeIsChanging(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
-        print("min: \(minValueSelected) -  max: \(maxValueSelected) - identifier: \(slider.identifier)")
+    func rangeIsChanging(event: RangeUISliderChangeEvent) {
+        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected)")
     }
 }

--- a/RangeUISliderDemo/SetupProgrammaticViewController.swift
+++ b/RangeUISliderDemo/SetupProgrammaticViewController.swift
@@ -77,7 +77,12 @@ class SetupProgrammaticViewController: UIViewController, RangeUISliderDelegate {
 
     }
 
-    func rangeChangeFinished(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
+    func rangeChangeFinished(
+        minValueSelected: CGFloat,
+        maxValueSelected: CGFloat,
+        slider: RangeUISlider,
+        userInteraction: Bool
+    ) {
         print("FINISH min: \(minValueSelected) -  max: \(maxValueSelected) - identifier: \(slider.identifier)")
     }
 

--- a/RangeUISliderDemo/SliderInsideTableViewViewController.swift
+++ b/RangeUISliderDemo/SliderInsideTableViewViewController.swift
@@ -46,6 +46,6 @@ class SliderInsideTableViewViewController: UITableViewController, RangeUISliderD
     }
 
     func rangeIsChanging(event: RangeUISliderChangeEvent) {
-        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected) - identifier: \(event.slider.identifier)")
+        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected)")
     }
 }

--- a/RangeUISliderDemo/SliderInsideTableViewViewController.swift
+++ b/RangeUISliderDemo/SliderInsideTableViewViewController.swift
@@ -39,18 +39,13 @@ class SliderInsideTableViewViewController: UITableViewController, RangeUISliderD
         tableView.isScrollEnabled = false
     }
 
-    func rangeIsChanging(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
-        print("values \(minValueSelected) - \(maxValueSelected)")
+    func rangeChangeFinished(event: RangeUISliderChangeFinishedEvent) {
+        tableView.isScrollEnabled = true
+        minValueSelectedLabel?.text = event.minValueSelected.description
+        maxValueSelectedLabel?.text = event.maxValueSelected.description
     }
 
-    func rangeChangeFinished(
-        minValueSelected: CGFloat,
-        maxValueSelected: CGFloat,
-        slider: RangeUISlider,
-        userInteraction: Bool
-    ) {
-        tableView.isScrollEnabled = true
-        minValueSelectedLabel?.text = minValueSelected.description
-        maxValueSelectedLabel?.text = maxValueSelected.description
+    func rangeIsChanging(event: RangeUISliderChangeEvent) {
+        print("min: \(event.minValueSelected) -  max: \(event.maxValueSelected) - identifier: \(event.slider.identifier)")
     }
 }

--- a/RangeUISliderDemo/SliderInsideTableViewViewController.swift
+++ b/RangeUISliderDemo/SliderInsideTableViewViewController.swift
@@ -43,7 +43,12 @@ class SliderInsideTableViewViewController: UITableViewController, RangeUISliderD
         print("values \(minValueSelected) - \(maxValueSelected)")
     }
 
-    func rangeChangeFinished(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
+    func rangeChangeFinished(
+        minValueSelected: CGFloat,
+        maxValueSelected: CGFloat,
+        slider: RangeUISlider,
+        userInteraction: Bool
+    ) {
         tableView.isScrollEnabled = true
         minValueSelectedLabel?.text = minValueSelected.description
         maxValueSelectedLabel?.text = maxValueSelected.description

--- a/Source/Logic/KnobGestureManager.swift
+++ b/Source/Logic/KnobGestureManager.swift
@@ -37,7 +37,7 @@ class KnobGestureManager {
             updateKnobAndRangeUsing(gesture: gesture, updateKnob: updateKnob)
         }
         if gesture.gestureRecognizer.state == .ended {
-            knobGestureManagerDelegate.rangeSelectionFinished()
+            knobGestureManagerDelegate.rangeSelectionFinished(userInteraction: true)
         }
     }
 

--- a/Source/Logic/KnobGestureManagerDelegate.swift
+++ b/Source/Logic/KnobGestureManagerDelegate.swift
@@ -11,5 +11,5 @@ import Foundation
 protocol KnobGestureManagerDelegate: AnyObject {
     func rangeChangeStarted()
     func rangeSelectionUpdate()
-    func rangeSelectionFinished()
+    func rangeSelectionFinished(userInteraction: Bool)
 }

--- a/Source/Logic/RangeUpdater.swift
+++ b/Source/Logic/RangeUpdater.swift
@@ -40,13 +40,14 @@ class RangeUpdater: KnobGestureManagerDelegate {
             || rangeSelected.maxValue != properties.previousRangeSelected.maxValue
     }
 
-    internal func rangeSelectionFinished() {
+    internal func rangeSelectionFinished(userInteraction: Bool) {
         let rangeSelected = calculateSelectedRange()
 
         if !rangeSelected.minValue.isNaN && !rangeSelected.maxValue.isNaN {
             delegate.rangeChangeFinished(
                 minValueSelected: rangeSelected.minValue,
-                maxValueSelected: rangeSelected.maxValue
+                maxValueSelected: rangeSelected.maxValue,
+                userInteraction: userInteraction
             )
         }
     }

--- a/Source/Logic/RangeUpdaterDelegate.swift
+++ b/Source/Logic/RangeUpdaterDelegate.swift
@@ -11,5 +11,5 @@ import UIKit
 protocol RangeUpdaterDelegate: AnyObject {
     func rangeChangeStarted()
     func rangeIsChanging(minValueSelected: CGFloat, maxValueSelected: CGFloat)
-    func rangeChangeFinished(minValueSelected: CGFloat, maxValueSelected: CGFloat)
+    func rangeChangeFinished(minValueSelected: CGFloat, maxValueSelected: CGFloat, userInteraction: Bool)
 }

--- a/Source/RangeSliderCoordinator.swift
+++ b/Source/RangeSliderCoordinator.swift
@@ -31,9 +31,9 @@ public class RangeSliderCoordinator: RangeUISliderDelegate {
      - parameter maxValueSelected: the maximum value selected.
      - parameter slider: the slider on which the range has been modified.
      */
-    public func rangeIsChanging(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
-        self.rangeSlider.minValueSelected = minValueSelected
-        self.rangeSlider.maxValueSelected = maxValueSelected
+    public func rangeIsChanging(event: RangeUISliderChangeEvent) {
+        self.rangeSlider.minValueSelected = event.minValueSelected
+        self.rangeSlider.maxValueSelected = event.maxValueSelected
     }
 
     /**
@@ -44,15 +44,10 @@ public class RangeSliderCoordinator: RangeUISliderDelegate {
      - parameter slider: the slider on which the range has been modified.
      - parameter userInteraction: a boolean indicating if the change comes from user interaction
      */
-    public func rangeChangeFinished(
-        minValueSelected: CGFloat,
-        maxValueSelected: CGFloat,
-        slider: RangeUISlider,
-        userInteraction: Bool
-    ) {
-        if userInteraction == true {
-            self.rangeSlider.minValueSelected = minValueSelected
-            self.rangeSlider.maxValueSelected = maxValueSelected
+    public func rangeChangeFinished(event: RangeUISliderChangeFinishedEvent) {
+        if event.userInteraction == true {
+            self.rangeSlider.minValueSelected = event.minValueSelected
+            self.rangeSlider.maxValueSelected = event.maxValueSelected
         }
     }
 }

--- a/Source/RangeSliderCoordinator.swift
+++ b/Source/RangeSliderCoordinator.swift
@@ -42,10 +42,18 @@ public class RangeSliderCoordinator: RangeUISliderDelegate {
      - parameter minValueSelected: the minimum value selected.
      - parameter maxValueSelected: the maximum value selected.
      - parameter slider: the slider on which the range has been modified.
+     - parameter userInteraction: a boolean indicating if the change comes from user interaction
      */
-    public func rangeChangeFinished(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
-        self.rangeSlider.minValueSelected = minValueSelected
-        self.rangeSlider.maxValueSelected = maxValueSelected
+    public func rangeChangeFinished(
+        minValueSelected: CGFloat,
+        maxValueSelected: CGFloat,
+        slider: RangeUISlider,
+        userInteraction: Bool
+    ) {
+        if userInteraction == true {
+            self.rangeSlider.minValueSelected = minValueSelected
+            self.rangeSlider.maxValueSelected = maxValueSelected
+        }
     }
 }
 #endif

--- a/Source/RangeUISliderDelegate.swift
+++ b/Source/RangeUISliderDelegate.swift
@@ -27,7 +27,7 @@ import UIKit
      - parameter maxValueSelected: the maximum value selected.
      - parameter slider: the slider on which the range has been modified.
      */
-    @objc optional func rangeIsChanging(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider)
+    @objc optional func rangeIsChanging(event: RangeUISliderChangeEvent)
 
     /**
      Calls the delegate when the user has finished the change of the range.
@@ -37,10 +37,5 @@ import UIKit
      - parameter slider: the slider on which the range has been modified.
      - parameter userInteraction: a boolean indicating if the interaction is from user (or a programattic change)
      */
-    @objc func rangeChangeFinished(
-        minValueSelected: CGFloat,
-        maxValueSelected: CGFloat,
-        slider: RangeUISlider,
-        userInteraction: Bool
-    )
+    @objc func rangeChangeFinished(event: RangeUISliderChangeFinishedEvent)
 }

--- a/Source/RangeUISliderDelegate.swift
+++ b/Source/RangeUISliderDelegate.swift
@@ -35,6 +35,12 @@ import UIKit
      - parameter minValueSelected: the minimum value selected.
      - parameter maxValueSelected: the maximum value selected.
      - parameter slider: the slider on which the range has been modified.
+     - parameter userInteraction: a boolean indicating if the interaction is from user (or a programattic change)
      */
-    @objc func rangeChangeFinished(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider)
+    @objc func rangeChangeFinished(
+        minValueSelected: CGFloat,
+        maxValueSelected: CGFloat,
+        slider: RangeUISlider,
+        userInteraction: Bool
+    )
 }

--- a/Source/RangeUISliderDelegateEvents.swift
+++ b/Source/RangeUISliderDelegateEvents.swift
@@ -1,0 +1,45 @@
+//
+//  RangeUISliderDelegateEvents.swift
+//  RangeUISlider
+//
+//  Created by Fabrizio Duroni on 07/07/22.
+//  Copyright © 2022 Fabrizio Duroni. All rights reserved.
+//
+
+import Foundation
+
+/**
+ A range change event.
+ */
+@objc public class RangeUISliderChangeEvent: NSObject {
+    /// The minimum value selected.
+    public let minValueSelected: CGFloat
+    /// The max value selected.
+    public let maxValueSelected: CGFloat
+    /// The slider that generated the event
+    public let slider: RangeUISlider
+
+    init(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider) {
+        self.minValueSelected = minValueSelected
+        self.maxValueSelected = maxValueSelected
+        self.slider = slider
+    }
+}
+
+@objc public class RangeUISliderChangeFinishedEvent: NSObject {
+    /// The minimum value selected.
+    public let minValueSelected: CGFloat
+    /// The max value selected.
+    public let maxValueSelected: CGFloat
+    /// The slider that generated the event.
+    public let slider: RangeUISlider
+    /// A boolean indicating if there was a user interaction.
+    public let userInteraction: Bool
+
+    init(minValueSelected: CGFloat, maxValueSelected: CGFloat, slider: RangeUISlider, userInteraction: Bool) {
+        self.minValueSelected = minValueSelected
+        self.maxValueSelected = maxValueSelected
+        self.slider = slider
+        self.userInteraction = userInteraction
+    }
+}

--- a/Source/UI/RangeUISlider.swift
+++ b/Source/UI/RangeUISlider.swift
@@ -729,9 +729,11 @@ open class RangeUISlider: UIView, ProgrammaticKnobChangeDelegate, RangeUpdaterDe
             knobsLabelNumberOfDecimal: knobsLabelNumberOfDecimal
         )
         delegate?.rangeIsChanging?(
-            minValueSelected: minValueSelected,
-            maxValueSelected: maxValueSelected,
-            slider: self
+            event: RangeUISliderChangeEvent(
+                minValueSelected: minValueSelected,
+                maxValueSelected: maxValueSelected,
+                slider: self
+            )
         )
     }
 
@@ -743,10 +745,12 @@ open class RangeUISlider: UIView, ProgrammaticKnobChangeDelegate, RangeUpdaterDe
             knobsLabelNumberOfDecimal: knobsLabelNumberOfDecimal
         )
         delegate?.rangeChangeFinished(
-            minValueSelected: minValueSelected,
-            maxValueSelected: maxValueSelected,
-            slider: self,
-            userInteraction: userInteraction
+            event: RangeUISliderChangeFinishedEvent(
+                minValueSelected: minValueSelected,
+                maxValueSelected: maxValueSelected,
+                slider: self,
+                userInteraction: userInteraction
+            )
         )
     }
 }

--- a/Source/UI/RangeUISlider.swift
+++ b/Source/UI/RangeUISlider.swift
@@ -551,7 +551,7 @@ open class RangeUISlider: UIView, ProgrammaticKnobChangeDelegate, RangeUpdaterDe
     }
 
     internal func programmaticChangeCompleted() {
-        rangeUpdater.rangeSelectionFinished()
+        rangeUpdater.rangeSelectionFinished(userInteraction: false)
     }
 
     // MARK: setup
@@ -735,7 +735,7 @@ open class RangeUISlider: UIView, ProgrammaticKnobChangeDelegate, RangeUpdaterDe
         )
     }
 
-    internal func rangeChangeFinished(minValueSelected: CGFloat, maxValueSelected: CGFloat) {
+    internal func rangeChangeFinished(minValueSelected: CGFloat, maxValueSelected: CGFloat, userInteraction: Bool) {
         components.knobs.animateLabels(shouldShow: showKnobsLabels)
         components.knobs.updateLabels(
             minValueSelected: minValueSelected,
@@ -745,7 +745,8 @@ open class RangeUISlider: UIView, ProgrammaticKnobChangeDelegate, RangeUpdaterDe
         delegate?.rangeChangeFinished(
             minValueSelected: minValueSelected,
             maxValueSelected: maxValueSelected,
-            slider: self
+            slider: self,
+            userInteraction: userInteraction
         )
     }
 }


### PR DESCRIPTION
Detect if the range change has been generated from human interaction or in a programmatic way

## Description
Now the RangeUISlider delegate protocol has an additional property that let the dev detect the source of the change

## Motivation and Context
*Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here.*

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [ ] New feature :sparkles: (non-breaking change which adds functionality)
- [X] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/RangeUISlider/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
